### PR TITLE
Updated the PHP quick starts to remove the redirect and redirectLink methods

### DIFF
--- a/docs/php_quickstart.md
+++ b/docs/php_quickstart.md
@@ -88,11 +88,8 @@ If request was successful, you should consider saving the poll url sent from Pay
 
 ```php
 if($response->success()) {
-    // Redirect the user to Paynow
-    $response->redirect();
-
     // Or if you prefer more control, get the link to redirect the user to, then use it as you see fit
-	$link = $response->redirectLink();
+	$link = $response->redirectUrl();
 
 	// Get the poll url (used to check the status of a transaction). You might want to save this in your DB
 	$pollUrl = $response->pollUrl();
@@ -164,11 +161,8 @@ $response = $paynow->send($payment);
 
 
 if($response->success()) {
-    // Redirect the user to Paynow
-    $response->redirect();
-
     // Or if you prefer more control, get the link to redirect the user to, then use it as you see fit
-    $link = $response->redirectLink();
+    $link = $response->redirectUrl();
 
 	$pollUrl = $response->pollUrl();
 

--- a/website/pages/en/index.js
+++ b/website/pages/en/index.js
@@ -240,12 +240,8 @@ $response = $paynow->send($payment);
 <MarkdownBlock>
 {`\`\`\`php  
 if($response->success()) {
-    // Redirect the user to Paynow
-    $response->redirect();
-
-    // Or if you prefer more control, get the link to 
-    // redirect the user to, then use it as you see fit
-    $link = $response->redirectLink();
+    // Get the link to redirect the user to, then use it as you see fit
+    $link = $response->redirectUrl();
 
     // Get the poll url (used to check the status of a transaction). 
     // You might want to save this in your DB


### PR DESCRIPTION
Just updating the docs to ensure that people don't call methods that were removed after the docs were written.

Removed all mentions of the redirect() method and changed the redirectLink to redirectUrl following the standards laid out for the SDKs last year